### PR TITLE
allow PWD max display length to be customised

### DIFF
--- a/config/synth-shell-prompt.config.default
+++ b/config/synth-shell-prompt.config.default
@@ -70,7 +70,7 @@ prompt_horizontal_padding=''    #
 prompt_final_padding=''         #
 segment_padding=' '             #
 enable_vertical_padding=true    # Add extra new line over prompt
-
+max_pwd_char="20"
 
 
 ##==============================================================================

--- a/synth-shell-prompt/synth-shell-prompt.sh
+++ b/synth-shell-prompt/synth-shell-prompt.sh
@@ -247,7 +247,7 @@ prompt_command_hook()
 	local elements=(${SSP_ELEMENTS[@]})
 	local user=$USER
 	local host=$HOSTNAME
-	local path="$(shortenPath "$PWD" 20)"
+	local path="$(shortenPath "$PWD" $SSP_MAX_PWD_CHAR)"
 	local git_branch="$(getGitBranch)"
 	local pyenv="$(getPyenv)"
 	local tf="$(getTerraform)"
@@ -352,6 +352,7 @@ prompt_command_hook()
 	SSP_COLORS_CLOCK=($font_color_clock $background_clock $texteffect_clock)
 	SSP_COLORS_INPUT=($font_color_input $background_input $texteffect_input)
 	SSP_VERTICAL_PADDING=$vertical_padding
+	SSP_MAX_PWD_CHAR=${max_pwd_char:-20}
 
 	SSP_GIT_SYNCED=$git_symbol_synced
 	SSP_GIT_AHEAD=$git_symbol_unpushed


### PR DESCRIPTION
I've used a shell default value on the loading of the var so all existing configs work with their length still as 20.
Variable in the config file is named "max_pwd_char".