### PR TITLE
Use actual python virtual environment name

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -30,16 +30,19 @@ You may add your name, email, a link to your personal web-site/blog/profile
 *	**mcgillij**  
 	2021 - Support for Python environments and terraform, and other fixes
 
-	
+
 *	**Sami Olmari**  
 	<sami@olmari.fi>  
 	www.olmari.fi  
 	2019 - Major improvements to `status.sh`
-	
-	
+
+
 *	**PeterJRiches**  
 	2019 - Proofreading of comments and explanation fixes
 
+
+* **Dhia Hmila**
+	2022 - Use Python environment's alternative name if it exists
 
 	
 

--- a/synth-shell-prompt/synth-shell-prompt.sh
+++ b/synth-shell-prompt/synth-shell-prompt.sh
@@ -196,8 +196,8 @@ getPyenv()
 		echo "$CONDA_DEFAULT_ENV"
 	## Python virtual environment
 	elif [ -n "${VIRTUAL_ENV:-}" ]; then
-        REGEX='PS1=\"\((.*?)\)\s\$\{PS1'
-        local pyenv=$(cat $VIRTUAL_ENV/bin/activate | perl -n -e"/$REGEX/ && print \$1" 2> /dev/null)
+        local regex='PS1=\"\((.*?)\)\s\$\{PS1'
+        local pyenv=$(cat $VIRTUAL_ENV/bin/activate | perl -n -e"/$regex/ && print \$1" 2> /dev/null)
         if [ -z "${pyenv}" ]; then
             local pyenv=$(basename ${VIRTUAL_ENV})
         fi

--- a/synth-shell-prompt/synth-shell-prompt.sh
+++ b/synth-shell-prompt/synth-shell-prompt.sh
@@ -195,8 +195,12 @@ getPyenv()
 	if [ -n "$CONDA_DEFAULT_ENV" ]; then
 		echo "$CONDA_DEFAULT_ENV"
 	## Python virtual environment
-	elif [ -n "$VIRTUAL_ENV" ]; then
-		local pyenv=$(basename ${VIRTUAL_ENV})
+	elif [ -n "${VIRTUAL_ENV:-}" ]; then
+        REGEX='PS1=\"\((.*?)\)\s\$\{PS1'
+        local pyenv=$(cat $VIRTUAL_ENV/bin/activate | perl -n -e"/$REGEX/ && print \$1" 2> /dev/null)
+        if [ -z "${pyenv}" ]; then
+            local pyenv=$(basename ${VIRTUAL_ENV})
+        fi
 		echo "$pyenv"
 	fi
 }


### PR DESCRIPTION
When creating a python environment, you can explicitly specify a name:

```bash
python -m venv .venv --prompt environment_name
```

In this case, the environment name is `environment_name` and not the directory name `.venv`.

In this PR, I attempt to retrieve the actual environment name from the `.venv/bin/activate` bash script using regex, if it fails revert to the directory name.